### PR TITLE
Update import statement to use 'editor' directory instead of 'communication'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import * as Alerts from "./icons/alerts";
 import * as Arrow from "./icons/arrow";
 import * as Charts from "./icons/charts";
 import * as Communication from "./icons/communication";
-import * as Editor from "./icons/communication";
+import * as Editor from "./icons/editor";
 import * as Education from "./icons/education";
 import * as Files from "./icons/files";
 import * as Finance from "./icons/finance";


### PR DESCRIPTION
This pull request updates the code snippet in src/index.ts to import the Editor icons from the src/icons/editor directory instead of the src/icons/communication directory.

This PR fixes #11